### PR TITLE
Use decorator keys to set overridden functions

### DIFF
--- a/packages/webpack-decorators/src/config/interceptorConfig.js
+++ b/packages/webpack-decorators/src/config/interceptorConfig.js
@@ -40,12 +40,13 @@ const onConfigChange = (module, ...targetFunctions) => {
     }
 };
 
-const registerDecorator = (moduleName, decorator, ...targetFunctions) => {
+const registerDecorator = (moduleName, decorator) => {
+    const targetFunctions = Object.keys(decorator);
     addModuleConfiguration(moduleName);
 
     interceptorConfig[moduleName].decorators.push(decorator);
 
-    [...targetFunctions, ...Object.keys(decorator)].forEach(func => 
+    targetFunctions.forEach(func => 
         interceptorConfig[moduleName].interceptedFunctions.add(func)
     );
 

--- a/packages/webpack-decorators/src/config/interceptorConfig.js
+++ b/packages/webpack-decorators/src/config/interceptorConfig.js
@@ -45,7 +45,7 @@ const registerDecorator = (moduleName, decorator, ...targetFunctions) => {
 
     interceptorConfig[moduleName].decorators.push(decorator);
 
-    targetFunctions.forEach(func => 
+    [...targetFunctions, ...Object.keys(decorator)].forEach(func => 
         interceptorConfig[moduleName].interceptedFunctions.add(func)
     );
 


### PR DESCRIPTION
Given a decorator -
  const decorator2 = {
    createElement: ...
    Component: ...
  }

we can change from registering as
registerDecorator('react', decorator2, 'createElement', 'Component');

into simply registering as
registerDecorator('react', decorator2);